### PR TITLE
fix: use logr-compatible log context access

### DIFF
--- a/pkg/pluginhelper/server.go
+++ b/pkg/pluginhelper/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"github.com/go-logr/logr"
 
 	"github.com/cloudnative-pg/cnpg-i-machinery/pkg/logging"
 )
@@ -44,12 +45,16 @@ type ServerEnricher func(*grpc.Server) error
 // for the CNPG-I infrastructure
 func CreateMainCmd(identityImpl identity.IdentityServer, enrichers ...ServerEnricher) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "pvc-backup",
+		Use: "plugin",
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			ctx := logging.NewIntoContext(
-				cmd.Context(),
-				viper.GetBool("debug"))
-			cmd.SetContext(ctx)
+			_, err := logr.FromContext(cmd.Context())
+			if err == nil {
+				// caller did not supply a logger, inject one
+				ctx := logging.NewIntoContext(
+					cmd.Context(),
+					viper.GetBool("debug"))
+				cmd.SetContext(ctx)
+			}
 		},
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
Instead of using custom keys in `context.Context`, use the logr methods for context access. This ensures that this logging adapter is compatible with others that use logr for contextual logging.

In the server command, look for a `logr.Logger` in the command context, and don't replace it if one is supplied by the caller. Since it's done in the `PersistentPreRun`, the caller can add their own logger to the returned `cobra.Command` before it gets invoked.