### PR TITLE
fix: Propagate the logr.Logger into the gRPC server handlers

### DIFF
--- a/pkg/pluginhelper/grpc.go
+++ b/pkg/pluginhelper/grpc.go
@@ -1,0 +1,62 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluginhelper
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+
+	"github.com/cloudnative-pg/cnpg-i-machinery/pkg/logging"
+)
+
+// Inject the passed logger into the gRPC call context for all inbound unary calls.
+//
+// Works around go-grpc's lack of a WithContext option to set a root context.
+func loggingUnaryServerInterceptor(logger logr.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		_ *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		newCtx := logging.IntoContext(ctx, logger)
+		return handler(newCtx, req)
+	}
+}
+
+// logInjectStream wraps a grpc.ServerStream and injects a logger into the context.
+type logInjectStream struct {
+	grpc.ServerStream
+	logger logr.Logger
+}
+
+// Inject the passed logger into the gRPC call context for all inbound streaming calls.
+func (s *logInjectStream) Context() context.Context {
+	return logging.IntoContext(s.ServerStream.Context(), s.logger)
+}
+
+// Inject the passed logger into the gRPC call context for all inbound streaming calls
+// by wrapping the ServerStream and overriding the Context() method.
+//
+// Works around go-grpc's lack of a WithContext option to set a root context.
+func loggingStreamServerInterceptor(logger logr.Logger) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return handler(srv, &logInjectStream{ss, logger})
+	}
+}

--- a/pkg/pluginhelper/server.go
+++ b/pkg/pluginhelper/server.go
@@ -155,9 +155,11 @@ func run(ctx context.Context, identityImpl identity.IdentityServer, enrichers ..
 	// Create GRPC server
 	serverOptions := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
+			loggingUnaryServerInterceptor(logger),
 			recovery.UnaryServerInterceptor(recovery.WithRecoveryHandlerContext(panicRecoveryHandler(listener))),
 		),
 		grpc.ChainStreamInterceptor(
+			loggingStreamServerInterceptor(logger),
 			recovery.StreamServerInterceptor(recovery.WithRecoveryHandlerContext(panicRecoveryHandler(listener))),
 		),
 	}


### PR DESCRIPTION
The context containing the injected logger was not being propagated to the gRPC server handler implementations.

go-grpc offers no way to provide a root Context to which the logger can be attached. 

Surprisingly I didn't find a simple package that provides these interceptors - in zapr, logr, etc - so a simple one is added to the helper. There's https://github.com/grpc-ecosystem/go-grpc-middleware/blob/main/interceptors/logging/examples/logr/example_test.go, but it adapts the logger to its own interface instead of just propagating the `logr.Logger`, and it's rather heavy for what it does.

Prior to this change, code in a gRPC handler like

```
_, err := logr.FromContext(ctx)
if err != nil {
   panic("missing logger from context")
}
```

would panic, and `logging.FromContext(ctx)` would silently return a new default logger.

Now `logging.FromContext(ctx)` will return the logger from the `plugin` command.

A plugin implementation can inject its own logger with something like

```
cmd := pluginhelper.CreateMainCmd(...)

zc := zap.NewProductionConfig()
z, err := zc.Build()
if err != nil {
	panic(fmt.Sprintf("while building logger: %v", err))
}

logger = zapr.NewLogger(z)

ctx := cmd.Context()
if ctx == nil {
    ctx = context.Background()
}
cmd.SetContext(logging.IntoContext(cmd.Context(), logger))
```

though in practice it'll customize the logger in non-trivial ways.

There's no test harness that stands up and exercises the gRPC server yet, so I didn't have anywhere to add specific test cover to validate this change.