### PR TITLE
ci: use a PAT for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,11 +26,11 @@ jobs:
       #   manually also for 1.0.0.
       - run: |
           npx release-please release-pr \
-            --token="${{ secrets.GITHUB_TOKEN }}" \
+            --token="${{ secrets.REPO_PAT }}" \
             --repo-url="${{ github.repository }}" \
             --bump-minor-pre-major=true \
             --release-as=0.1.0 \
-            --signoff "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>";
+            --signoff "Peggie <info@cloudnative-pg.io>";
           npx release-please github-release \
-            --token="${{ secrets.GITHUB_TOKEN }}" \
+            --token="${{ secrets.REPO_PAT }}" \
             --repo-url="${{ github.repository }}" \


### PR DESCRIPTION
The default GitHub token cannot run checks on the PRs opened by release-please. We change the secret to a personal access one.