### PR TITLE
feat: add `BuildSetStatusResponse` to pluginhelper

### DIFF
--- a/pkg/pluginhelper/helper.go
+++ b/pkg/pluginhelper/helper.go
@@ -182,14 +182,14 @@ func (*Data) DecodeBackup(backupDefinition []byte) (*apiv1.Backup, error) {
 	return &backup, nil
 }
 
-// GetKind gets the Kubernetes object kind from its JSON representation
+// GetKind gets the Kubernetes object kind from its JSON representation.
 func GetKind(definition []byte) (string, error) {
 	var genericObject struct {
 		Kind string `json:"kind"`
 	}
 
 	if err := json.Unmarshal(definition, &genericObject); err != nil {
-		return "", err
+		return "", fmt.Errorf("while unmarshalling resource definition: %w", err)
 	}
 
 	return genericObject.Kind, nil

--- a/pkg/pluginhelper/status.go
+++ b/pkg/pluginhelper/status.go
@@ -1,0 +1,35 @@
+package pluginhelper
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
+)
+
+// BuildSetStatusResponse accepts as values:
+// a) any struct containing values that can be converted into a valid JSON object. This will be set as the plugin
+// status
+// b) nil value. This is translated as a 'noop' (no changes to the plugin status will be done) in the CNPG main
+// reconciliation loop
+// c) any empty struct this will be translated as a cleanup of the currently registered plugin status.
+// Examples:
+// Lets suppose this function is invoked by a plugin named 'test'
+// a) Body{Uptime: 100} will result into .status.plugins["test"] = '{"Uptime": 100}'
+// b) will leave the status unchanged, so it will stay as the currently set value, example '{"Uptime": 100}'
+// c) Body{} will result into .status.plugins["test"] = '{}'
+func BuildSetStatusResponse(obj any) (*operator.SetClusterStatusResponse, error) {
+	if obj == nil {
+		return &operator.SetClusterStatusResponse{JsonStatus: nil}, nil
+	}
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	var js map[string]interface{}
+	if err := json.Unmarshal(b, &js); err != nil {
+		return nil, fmt.Errorf("invalid json: not an object: '%s'", string(b))
+	}
+	return &operator.SetClusterStatusResponse{
+		JsonStatus: b,
+	}, nil
+}

--- a/pkg/pluginhelper/status.go
+++ b/pkg/pluginhelper/status.go
@@ -8,40 +8,63 @@ import (
 	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
 )
 
-// SetStatusResponseBuilder a SetStatus response builder
+// ErrNilObject is used when a nill object is passed to the builder.
+var ErrNilObject = errors.New("nil object passed, use NoOpResponse")
+
+// NotAnObjectError is used when the passed value cannot be represented
+// as a JSON object.
+type NotAnObjectError struct {
+	representation []byte
+}
+
+func (err NotAnObjectError) Error() string {
+	return fmt.Sprintf(
+		"the passed variable cannot be serialized as a JSON object: %s",
+		err.representation,
+	)
+}
+
+// SetStatusResponseBuilder a SetStatus response builder.
 type SetStatusResponseBuilder struct{}
 
-// NewSetStatusResponseBuilder is an helper that creates the SetStatus endpoint responses
+// NewSetStatusResponseBuilder is an helper that creates the SetStatus endpoint responses.
 func NewSetStatusResponseBuilder() *SetStatusResponseBuilder {
 	return &SetStatusResponseBuilder{}
 }
 
-// NoOpResponse this response will ensure that no changes will be done to the plugin status
+// NoOpResponse this response will ensure that no changes will be done to the plugin status.
 func (s SetStatusResponseBuilder) NoOpResponse() *operator.SetClusterStatusResponse {
 	return &operator.SetClusterStatusResponse{JsonStatus: nil}
 }
 
-// SetEmptyStatusResponse will set the plugin status to an empty object '{}'
+// SetEmptyStatusResponse will set the plugin status to an empty object '{}'.
 func (s SetStatusResponseBuilder) SetEmptyStatusResponse() *operator.SetClusterStatusResponse {
-	b, _ := json.Marshal(map[string]string{})
+	b, err := json.Marshal(map[string]string{})
+	if err != nil {
+		panic("JSON mashaller failed for empty map")
+	}
+
 	return &operator.SetClusterStatusResponse{JsonStatus: b}
 }
 
-// JsonStatusResponse requires a struct or map that can be translated to a JSON object, will set the status to the passed
-// object
-func (s SetStatusResponseBuilder) JsonStatusResponse(obj any) (*operator.SetClusterStatusResponse, error) {
+// JSONStatusResponse requires a struct or map that can be translated to a JSON object,
+// will set the status to the passed object.
+func (s SetStatusResponseBuilder) JSONStatusResponse(obj any) (*operator.SetClusterStatusResponse, error) {
 	if obj == nil {
-		return nil, errors.New("nil object passed, use NoOpResponse")
+		return nil, ErrNilObject
 	}
-	b, err := json.Marshal(obj)
+
+	jsonObject, err := json.Marshal(obj)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("while marshalling resource definition: %w", err)
 	}
+
 	var js map[string]interface{}
-	if err := json.Unmarshal(b, &js); err != nil {
-		return nil, fmt.Errorf("invalid json: not an object: '%s'", string(b))
+	if err := json.Unmarshal(jsonObject, &js); err != nil {
+		return nil, NotAnObjectError{representation: jsonObject}
 	}
+
 	return &operator.SetClusterStatusResponse{
-		JsonStatus: b,
+		JsonStatus: jsonObject,
 	}, nil
 }

--- a/pkg/pluginhelper/status.go
+++ b/pkg/pluginhelper/status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
 )
 

--- a/pkg/pluginhelper/status.go
+++ b/pkg/pluginhelper/status.go
@@ -2,24 +2,35 @@ package pluginhelper
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/cloudnative-pg/cnpg-i/pkg/operator"
 )
 
-// BuildSetStatusResponse accepts as values:
-// a) any struct containing values that can be converted into a valid JSON object. This will be set as the plugin
-// status
-// b) nil value. This is translated as a 'noop' (no changes to the plugin status will be done) in the CNPG main
-// reconciliation loop
-// c) any empty struct this will be translated as a cleanup of the currently registered plugin status.
-// Examples:
-// Lets suppose this function is invoked by a plugin named 'test'
-// a) Body{Uptime: 100} will result into .status.plugins["test"] = '{"Uptime": 100}'
-// b) will leave the status unchanged, so it will stay as the currently set value, example '{"Uptime": 100}'
-// c) Body{} will result into .status.plugins["test"] = '{}'
-func BuildSetStatusResponse(obj any) (*operator.SetClusterStatusResponse, error) {
+// SetStatusResponseBuilder a SetStatus response builder
+type SetStatusResponseBuilder struct{}
+
+// NewSetStatusResponseBuilder is an helper that creates the SetStatus endpoint responses
+func NewSetStatusResponseBuilder() *SetStatusResponseBuilder {
+	return &SetStatusResponseBuilder{}
+}
+
+// NoOpResponse this response will ensure that no changes will be done to the plugin status
+func (s SetStatusResponseBuilder) NoOpResponse() *operator.SetClusterStatusResponse {
+	return &operator.SetClusterStatusResponse{JsonStatus: nil}
+}
+
+// SetEmptyStatusResponse will set the plugin status to an empty object '{}'
+func (s SetStatusResponseBuilder) SetEmptyStatusResponse() *operator.SetClusterStatusResponse {
+	b, _ := json.Marshal(map[string]string{})
+	return &operator.SetClusterStatusResponse{JsonStatus: b}
+}
+
+// JsonStatusResponse requires a struct or map that can be translated to a JSON object, will set the status to the passed
+// object
+func (s SetStatusResponseBuilder) JsonStatusResponse(obj any) (*operator.SetClusterStatusResponse, error) {
 	if obj == nil {
-		return &operator.SetClusterStatusResponse{JsonStatus: nil}, nil
+		return nil, errors.New("nil object passed, use NoOpResponse")
 	}
 	b, err := json.Marshal(obj)
 	if err != nil {

--- a/pkg/pluginhelper/status_test.go
+++ b/pkg/pluginhelper/status_test.go
@@ -1,0 +1,38 @@
+package pluginhelper
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BuildSetStatusResponse", func() {
+	type test struct {
+		Name string `json:"string"`
+	}
+
+	It("should properly form a response with an object, allowing the plugins to set the status", func() {
+		jsonBody := test{Name: "test"}
+		b, err := BuildSetStatusResponse(&jsonBody)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(b.JsonStatus).ToNot(BeEmpty())
+	})
+
+	It("should properly form a response for a 'nil' value, allowing the plugins to do a 'noop'", func() {
+		b, err := BuildSetStatusResponse(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(b.JsonStatus).To(BeNil())
+	})
+
+	It("should serialize an empty JSONStatus, allowing the plugins to reset its status", func() {
+		jsonBody := test{}
+		b, err := BuildSetStatusResponse(&jsonBody)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(b.JsonStatus).ToNot(BeEmpty())
+	})
+
+	It("should return an error if it is an invalid JSON object", func() {
+		wrongType := 4
+		_, err := BuildSetStatusResponse(&wrongType)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/pluginhelper/status_test.go
+++ b/pkg/pluginhelper/status_test.go
@@ -12,27 +12,24 @@ var _ = Describe("BuildSetStatusResponse", func() {
 
 	It("should properly form a response with an object, allowing the plugins to set the status", func() {
 		jsonBody := test{Name: "test"}
-		b, err := BuildSetStatusResponse(&jsonBody)
+		b, err := NewSetStatusResponseBuilder().JsonStatusResponse(&jsonBody)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(b.JsonStatus).ToNot(BeEmpty())
 	})
 
 	It("should properly form a response for a 'nil' value, allowing the plugins to do a 'noop'", func() {
-		b, err := BuildSetStatusResponse(nil)
-		Expect(err).NotTo(HaveOccurred())
+		b := NewSetStatusResponseBuilder().NoOpResponse()
 		Expect(b.JsonStatus).To(BeNil())
 	})
 
 	It("should serialize an empty JSONStatus, allowing the plugins to reset its status", func() {
-		jsonBody := test{}
-		b, err := BuildSetStatusResponse(&jsonBody)
-		Expect(err).NotTo(HaveOccurred())
+		b := NewSetStatusResponseBuilder().SetEmptyStatusResponse()
 		Expect(b.JsonStatus).ToNot(BeEmpty())
 	})
 
 	It("should return an error if it is an invalid JSON object", func() {
 		wrongType := 4
-		_, err := BuildSetStatusResponse(&wrongType)
+		_, err := NewSetStatusResponseBuilder().JsonStatusResponse(&wrongType)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/pluginhelper/status_test.go
+++ b/pkg/pluginhelper/status_test.go
@@ -12,24 +12,24 @@ var _ = Describe("BuildSetStatusResponse", func() {
 
 	It("should properly form a response with an object, allowing the plugins to set the status", func() {
 		jsonBody := test{Name: "test"}
-		b, err := NewSetStatusResponseBuilder().JsonStatusResponse(&jsonBody)
+		b, err := NewSetStatusResponseBuilder().JSONStatusResponse(&jsonBody)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(b.JsonStatus).ToNot(BeEmpty())
+		Expect(b.GetJsonStatus()).ToNot(BeEmpty())
 	})
 
 	It("should properly form a response for a 'nil' value, allowing the plugins to do a 'noop'", func() {
 		b := NewSetStatusResponseBuilder().NoOpResponse()
-		Expect(b.JsonStatus).To(BeNil())
+		Expect(b.GetJsonStatus()).To(BeNil())
 	})
 
 	It("should serialize an empty JSONStatus, allowing the plugins to reset its status", func() {
 		b := NewSetStatusResponseBuilder().SetEmptyStatusResponse()
-		Expect(b.JsonStatus).ToNot(BeEmpty())
+		Expect(b.GetJsonStatus()).ToNot(BeEmpty())
 	})
 
 	It("should return an error if it is an invalid JSON object", func() {
 		wrongType := 4
-		_, err := NewSetStatusResponseBuilder().JsonStatusResponse(&wrongType)
+		_, err := NewSetStatusResponseBuilder().JSONStatusResponse(&wrongType)
 		Expect(err).To(HaveOccurred())
 	})
 })


### PR DESCRIPTION
This commit introduces a new public method named `BuildSetStatusResponse`. This will allow the users to easily serialize a body response needed for the setStatus endpoint