### PR TITLE
feat: configurable decoder of CNPG resources, lenient and strict

### DIFF
--- a/pkg/pluginhelper/decoder/backup.go
+++ b/pkg/pluginhelper/decoder/backup.go
@@ -29,11 +29,22 @@ func getBackupGVK() schema.GroupVersionKind {
 	}
 }
 
-// DecodeBackup decodes a JSON representation of a backup.
-func DecodeBackup(backupDefinition []byte) (*apiv1.Backup, error) {
+// DecodeBackupLenient decodes a JSON representation of a backup.
+func DecodeBackupLenient(backupDefinition []byte) (*apiv1.Backup, error) {
 	var backup apiv1.Backup
 
-	if err := DecodeObject(backupDefinition, &backup, getBackupGVK()); err != nil {
+	if err := DecodeObjectLenient(backupDefinition, &backup); err != nil {
+		return nil, err
+	}
+
+	return &backup, nil
+}
+
+// DecodeBackupStrict decodes a JSON representation of a backup.
+func DecodeBackupStrict(backupDefinition []byte) (*apiv1.Backup, error) {
+	var backup apiv1.Backup
+
+	if err := DecodeObjectStrict(backupDefinition, &backup, getBackupGVK()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/pluginhelper/decoder/backup_test.go
+++ b/pkg/pluginhelper/decoder/backup_test.go
@@ -28,14 +28,14 @@ var _ = Describe("DecodeBackup", func() {
 	DescribeTable(
 		"DecodeBackup",
 		func(backupJSON []byte, expected *v1.Backup, succeeds bool) {
-			backup, err := DecodeBackup(backupJSON)
-			if err != nil {
-				Expect(succeeds).To(BeFalse())
-			} else {
-				Expect(succeeds).To(BeTrue())
+			backup, err := DecodeBackupStrict(backupJSON)
+			if !succeeds {
+				Expect(err).To(HaveOccurred())
+				return
 			}
 
 			Expect(backup).To(Equal(expected))
+			Expect(backup.GroupVersionKind()).To(Equal(getBackupGVK()))
 		},
 		Entry(
 			"when the backup JSON is valid",

--- a/pkg/pluginhelper/decoder/cluster.go
+++ b/pkg/pluginhelper/decoder/cluster.go
@@ -29,11 +29,22 @@ func getClusterGVK() schema.GroupVersionKind {
 	}
 }
 
-// DecodeClusterJSON decodes a JSON representation of a cluster.
-func DecodeClusterJSON(clusterJSON []byte) (*apiv1.Cluster, error) {
+// DecodeClusterLenient decodes a JSON representation of a cluster.
+func DecodeClusterLenient(clusterJSON []byte) (*apiv1.Cluster, error) {
 	var result apiv1.Cluster
 
-	if err := DecodeObject(clusterJSON, &result, getClusterGVK()); err != nil {
+	if err := DecodeObjectLenient(clusterJSON, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// DecodeClusterStrict decodes a JSON representation of a cluster.
+func DecodeClusterStrict(clusterJSON []byte) (*apiv1.Cluster, error) {
+	var result apiv1.Cluster
+
+	if err := DecodeObjectStrict(clusterJSON, &result, getClusterGVK()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/pluginhelper/decoder/cluster_test.go
+++ b/pkg/pluginhelper/decoder/cluster_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Decode Functions", func() {
 	DescribeTable(
 		"Decode Functions",
 		func(clusterJSON []byte, succeeds bool) {
-			cluster, err := DecodeClusterJSON(clusterJSON)
+			cluster, err := DecodeClusterStrict(clusterJSON)
 			if !succeeds {
 				Expect(err).To(HaveOccurred())
 				return

--- a/pkg/pluginhelper/decoder/decoder.go
+++ b/pkg/pluginhelper/decoder/decoder.go
@@ -36,10 +36,19 @@ func (e *WrongObjectTypeError) Error() string {
 	return fmt.Sprintf("received wrong GVK '%v' expected '%v'", e.receivedGVK.String(), e.expectedGVK.String())
 }
 
-// DecodeObject decodes a JSON representation of an object.
-func DecodeObject(objectJSON []byte, object runtime.Object, expectedGVK schema.GroupVersionKind) error {
+// DecodeObjectLenient decodes a JSON representation of an object.
+func DecodeObjectLenient(objectJSON []byte, object runtime.Object) error {
 	if err := json.Unmarshal(objectJSON, object); err != nil {
 		return fmt.Errorf("error unmarshalling object JSON: %w", err)
+	}
+
+	return nil
+}
+
+// DecodeObjectStrict decodes a JSON representation of an object.
+func DecodeObjectStrict(objectJSON []byte, object runtime.Object, expectedGVK schema.GroupVersionKind) error {
+	if err := DecodeObjectLenient(objectJSON, object); err != nil {
+		return err
 	}
 
 	if object.GetObjectKind().GroupVersionKind() != expectedGVK {

--- a/pkg/pluginhelper/decoder/decoder_test.go
+++ b/pkg/pluginhelper/decoder/decoder_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Generic decoder", func() {
 		"Generic decoder",
 		func(objectJSON []byte, succeeds bool) {
 			var pod corev1.Pod
-			err := DecodeObject(objectJSON, &pod, getPodGVK())
+			err := DecodeObjectStrict(objectJSON, &pod, getPodGVK())
 			if !succeeds {
 				Expect(err).To(HaveOccurred())
 				return

--- a/pkg/pluginhelper/decoder/pod.go
+++ b/pkg/pluginhelper/decoder/pod.go
@@ -33,7 +33,7 @@ func getPodGVK() schema.GroupVersionKind {
 func DecodePodJSON(podJSON []byte) (*corev1.Pod, error) {
 	var result corev1.Pod
 
-	if err := DecodeObject(podJSON, &result, getPodGVK()); err != nil {
+	if err := DecodeObjectStrict(podJSON, &result, getPodGVK()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
To support operators based on CNPG but having different API group, this patch adds function to decode them strictly and leniently.

Strict decoding verifies the GVK, and lenient decoding doesn't.