### PR TITLE
fix: logging setup in http.CreateMainCmd

### DIFF
--- a/pkg/pluginhelper/http/server.go
+++ b/pkg/pluginhelper/http/server.go
@@ -62,7 +62,7 @@ func CreateMainCmd(identityImpl identity.IdentityServer, enrichers ...ServerEnri
 		Use: "serve",
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			_, err := logr.FromContext(cmd.Context())
-			if err == nil {
+			if err != nil {
 				// caller did not supply a logger, inject one
 				flags := log.NewFlags(zap.Options{Development: viper.GetBool("debug")})
 				flags.ConfigureLogging()


### PR DESCRIPTION
the predicate checking for existing logging has the wrong polarity.
See fix in use in https://github.com/cloudnative-pg/cnpg-i-hello-world/pull/158
