### PR TITLE
feat: reload ssl cert to allow zero downtime rotation

### DIFF
--- a/pkg/pluginhelper/http/server.go
+++ b/pkg/pluginhelper/http/server.go
@@ -279,7 +279,7 @@ func (s *Server) buildTLSConfig(ctx context.Context) (*tls.Config, error) {
 
 	return &tls.Config{
 		ClientAuth: tls.RequireAndVerifyClientCert,
-		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			cert, err := tls.LoadX509KeyPair(s.ServerCertPath, s.ServerKeyPath)
 			if err != nil {
 				logger.Error(err, "failed to load server key pair")

--- a/pkg/pluginhelper/http/server.go
+++ b/pkg/pluginhelper/http/server.go
@@ -266,12 +266,6 @@ func (s *Server) buildTLSConfig(ctx context.Context) (*tls.Config, error) {
 		"clientCertPath", s.ClientCertPath,
 	)
 
-	cert, err := tls.LoadX509KeyPair(s.ServerCertPath, s.ServerKeyPath)
-	if err != nil {
-		logger.Error(err, "failed to load server key pair")
-		return nil, fmt.Errorf("failed to load server key pair: %w", err)
-	}
-
 	caCertPool := x509.NewCertPool()
 	caBytes, err := os.ReadFile(filepath.Clean(s.ClientCertPath))
 	if err != nil {
@@ -284,10 +278,18 @@ func (s *Server) buildTLSConfig(ctx context.Context) (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		Certificates: []tls.Certificate{cert},
-		ClientCAs:    caCertPool,
-		MinVersion:   tls.VersionTLS13,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(s.ServerCertPath, s.ServerKeyPath)
+			if err != nil {
+				logger.Error(err, "failed to load server key pair")
+				return nil, fmt.Errorf("failed to load server key pair: %w", err)
+			}
+
+			return &cert, nil
+		},
+		ClientCAs:  caCertPool,
+		MinVersion: tls.VersionTLS13,
 	}, nil
 }
 

--- a/pkg/pluginhelper/http/server_test.go
+++ b/pkg/pluginhelper/http/server_test.go
@@ -81,8 +81,14 @@ var _ = Describe("BuildTLSConfig", func() {
 		tlsConfig, err := server.buildTLSConfig(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(tlsConfig).ToNot(BeNil())
-		Expect(tlsConfig.Certificates).To(HaveLen(1))
+		Expect(tlsConfig.GetCertificate).ToNot(BeNil())
 		Expect(tlsConfig.ClientCAs.Subjects()).ToNot(BeEmpty()) //nolint: staticcheck
 		Expect(tlsConfig.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+
+		cert, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{
+			ServerName: "localhost",
+		})
+		Expect(err).Error().NotTo(HaveOccurred())
+		Expect(cert).NotTo(BeNil())
 	})
 })

--- a/pkg/pluginhelper/http/server_test.go
+++ b/pkg/pluginhelper/http/server_test.go
@@ -85,9 +85,7 @@ var _ = Describe("BuildTLSConfig", func() {
 		Expect(tlsConfig.ClientCAs.Subjects()).ToNot(BeEmpty()) //nolint: staticcheck
 		Expect(tlsConfig.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
 
-		cert, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{
-			ServerName: "localhost",
-		})
+		cert, err := tlsConfig.GetCertificate(nil)
 		Expect(err).Error().NotTo(HaveOccurred())
 		Expect(cert).NotTo(BeNil())
 	})


### PR DESCRIPTION
Some context:

The idea is to make the process reload TLS certificates when they change (via cert-manager), without restarting it or error'ing in the pod. I am not sure if the pool that's setup would also require something similar (there's no hook, it would need a process to watch most likely). Since the `*grpc.Server` is in this repository, this should then benefit all plugins, etc..