### PR TITLE
chore: support running with golangci-lint v2.2.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,9 +6,11 @@ linters:
     - exhaustruct
     - funlen
     - mnd
+    - noinlineerr
     - paralleltest
     - testpackage
     - wsl
+    - wsl_v5
   settings:
     lll:
       line-length: 120
@@ -27,6 +29,10 @@ linters:
       - linters:
           - lll
         source: //\s*\+
+      - linters:
+          - revive
+        path: pkg/pluginhelper/common/
+        text: avoid meaningless package names
     paths:
       - third_party$
       - builtin$

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,6 +18,8 @@ tasks:
     env:
       # renovate: datasource=git-refs depName=golangci-lint lookupName=https://github.com/sagikazarmark/daggerverse currentValue=main
       DAGGER_GOLANGCI_LINT_SHA: ceffda4aebd349a24fc00e591b4ed9b801535b65
+      # renovate: datasource=docker depName=golangci/golangci-lint versioning=semver
+      GOLANGCI_LINT_VERSION: v2.2.1
     cmds:
       - >
         GITHUB_REF= dagger -s call -m github.com/sagikazarmark/daggerverse/golangci-lint@${DAGGER_GOLANGCI_LINT_SHA}

--- a/pkg/pluginhelper/http/grpc.go
+++ b/pkg/pluginhelper/http/grpc.go
@@ -62,6 +62,7 @@ func logFailedRequestsUnaryServerInterceptor(logger log.Logger) grpc.UnaryServer
 // logInjectStream wraps a grpc.ServerStream and injects a logger into the context.
 type logInjectStream struct {
 	grpc.ServerStream
+
 	logger log.Logger
 }
 


### PR DESCRIPTION
Additionally, it pins the golangci-lint version and enables renovate on it.