### PR TITLE
fix: reduce noisy logs for expected gRPC errors

### DIFF
--- a/pkg/pluginhelper/http/grpc.go
+++ b/pkg/pluginhelper/http/grpc.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // loggingUnaryServerInterceptor injects the passed logger into the gRPC call context for all inbound unary calls.
@@ -47,7 +49,7 @@ func logFailedRequestsUnaryServerInterceptor(logger log.Logger) grpc.UnaryServer
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
 		result, err := handler(ctx, req)
-		if err != nil {
+		if status.Convert(err).Code() == codes.Unknown {
 			logger.Error(
 				err,
 				"Error while handling GRPC request",
@@ -85,7 +87,7 @@ func loggingStreamServerInterceptor(logger log.Logger) grpc.StreamServerIntercep
 func logFailedRequestsStreamServerInterceptor(logger log.Logger) grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		err := handler(srv, ss)
-		if err != nil {
+		if status.Convert(err).Code() == codes.Unknown {
 			logger.Error(
 				err,
 				"Error while handling GRPC request",


### PR DESCRIPTION
Previously, every failed gRPC RPC call was logged as an error with a full stack trace, even when the failure was due to an expected status code.

With this patch, error messages and stack traces are logged only when the gRPC status code is not explicitly set. This prevents the server from logging errors for harmless cases such as `NotFound (404)`.